### PR TITLE
SCRS-11597 Send PPOB even if it is the same as RO on submission

### DIFF
--- a/app/models/validation/APIValidation.scala
+++ b/app/models/validation/APIValidation.scala
@@ -25,6 +25,8 @@ import play.api.libs.json.Reads.{maxLength, pattern}
 import play.api.libs.json.{Format, JsString, OFormat, Reads, Writes}
 import play.api.libs.functional.syntax._
 
+import scala.util.matching.Regex
+
 object APIValidation extends APIValidation
 
 trait APIValidation extends BaseJsonFormatting
@@ -102,8 +104,22 @@ trait AddressValidator {
       ppob => ppob.postcode.isDefined || ppob.country.isDefined
     }
   }
-  val lineValidator = readToFmt(length(27) keepAnd pattern("^[a-zA-Z0-9,.\\(\\)/&amp;'&quot;\\-]{1}[a-zA-Z0-9, .\\(\\)/&amp;'&quot;\\-]{0,26}$".r))
-  val line4Validator = readToFmt(length(18) keepAnd pattern("^[a-zA-Z0-9,.\\(\\)/&amp;'&quot;\\-]{1}[a-zA-Z0-9, .\\(\\)/&amp;'&quot;\\-]{0,17}$".r))
-  val postcodeValidator = readToFmt(length(20) keepAnd pattern("^[A-Z]{1,2}[0-9][0-9A-Z]? [0-9][A-Z]{2}$".r))
-  val countryValidator = readToFmt(length(20) keepAnd pattern("^[A-Za-z0-9]{1}[A-Za-z 0-9]{0,19}$".r))
+
+  private def regexWrap(regex : String): Regex = {
+    ("^" + regex + "$").r
+  }
+
+  val linePattern = regexWrap("[a-zA-Z0-9,.\\(\\)/&amp;'&quot;\\-]{1}[a-zA-Z0-9, .\\(\\)/&amp;'&quot;\\-]{0,26}")
+  val line4Pattern = regexWrap("[a-zA-Z0-9,.\\(\\)/&amp;'&quot;\\-]{1}[a-zA-Z0-9, .\\(\\)/&amp;'&quot;\\-]{0,17}")
+  val postCodePattern = regexWrap("[A-Z]{1,2}[0-9][0-9A-Z]? [0-9][A-Z]{2}")
+  val countryPattern = regexWrap("[A-Za-z0-9]{1}[A-Za-z 0-9]{0,19}")
+
+  val lineInvert = regexWrap("[a-zA-Z0-9,.\\(\\)/&amp;'&quot;\\- ]")
+  val postCodeInvert = regexWrap("[A-Z0-9 ]")
+  val countryInvert = regexWrap("[A-Za-z0-9 ]")
+
+  val lineValidator = readToFmt(length(27) keepAnd pattern(linePattern))
+  val line4Validator = readToFmt(length(18) keepAnd pattern(line4Pattern))
+  val postcodeValidator = readToFmt(length(20) keepAnd pattern(postCodePattern))
+  val countryValidator = readToFmt(length(20) keepAnd pattern(countryPattern))
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -6,6 +6,8 @@ POST       /corporation-tax-registration/process-incorp                         
 
 POST       /corporation-tax-registration/acknowledgement-confirmation                       @controllers.CorporationTaxRegistrationController.acknowledgementConfirmation(ackref : String)
 
+POST       /corporation-tax-registration/check-ro-address                                   @controllers.CorporationTaxRegistrationController.roAddressValid
+
 # PUT URLS WITHOUT A REG ID ABOVE THIS LINE !
 
 GET        /corporation-tax-registration/:registrationId                                    @controllers.CorporationTaxRegistrationController.retrieveCorporationTaxRegistration(registrationId)

--- a/test/audit/UserRegistrationSubmissionEventSpec.scala
+++ b/test/audit/UserRegistrationSubmissionEventSpec.scala
@@ -112,14 +112,15 @@ class UserRegistrationSubmissionEventSpec extends UnitSpec {
       Json.toJson(testModel)(SubmissionEventDetail.writes) shouldBe expected
     }
 
-    "construct full json as per definition when the ETMP feature flag is disabled" in {
-      System.setProperty("feature.etmpHoldingPen", "false")
+    "construct full json as per definition when the transaction ID is missing" in {
+      System.setProperty("feature.etmpHoldingPen", "true")
 
       val expected = Json.parse(
         s"""
           |{
           |   "journeyId": "$regId",
           |   "acknowledgementReference": "$ackRef",
+          |   "desSubmissionState": "partial",
           |   "registrationMetadata": {
           |      "businessType": "Limited company",
           |      "authProviderId": "$authProviderId",
@@ -136,17 +137,6 @@ class UserRegistrationSubmissionEventSpec extends UnitSpec {
           |      "companiesHouseCompanyName": "Company Co",
           |      "returnsOnCT61": false,
           |      "companyACharity": false,
-          |      "businessAddress": {
-          |         "transactionId": "$transactionId",
-          |         "addressEntryMethod": "LOOKUP",
-          |         "addressLine1": "14 Matheson House",
-          |         "addressLine2": "Grange Central",
-          |         "addressLine3": "Town Centre",
-          |         "addressLine4": "Telford",
-          |         "postCode": "TF3 4ER",
-          |         "country": "United Kingdom",
-          |         "uprn": "$uprn"
-          |      },
           |      "businessContactName": {
           |         "firstName": "Billy",
           |         "middleNames": "bob",
@@ -164,7 +154,7 @@ class UserRegistrationSubmissionEventSpec extends UnitSpec {
       val testModel = SubmissionEventDetail(
         regId,
         authProviderId,
-        Some(transactionId),
+        None,
         Some(uprn),
         "LOOKUP",
         Json.toJson(InterimDesRegistration(


### PR DESCRIPTION
# SCRS-11597 Send PPOB even if it is the same as RO on submission

**New feature** 

* Added new route /corporation-tax-registration/check-ro-address to check if an RO address is valid and return it as a PPOB
* Convert RO addressses with no saved PPOB to PPOBs on DES submission but audit events remain unchanged.

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack & Performance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message