### PR TITLE
SCRS-11761 PPOB Reads has now been amended to normalise addresses

### DIFF
--- a/app/controllers/CompanyDetailsController.scala
+++ b/app/controllers/CompanyDetailsController.scala
@@ -65,7 +65,7 @@ trait CompanyDetailsController extends BaseController with AuthorisedActions {
     implicit request =>
       val timer = metricsService.updateCompanyDetailsCRTimer.time()
       withJsonBody[CompanyDetails]{
-        companyDetails => companyDetailsService.updateCompanyDetails(registrationID, companyDetails).map{
+        companyDetails => companyDetailsService.updateCompanyDetails(registrationID, companyDetails).map {
           case Some(details) => timer.stop()
             Ok(mapToResponse(registrationID, details))
           case None => timer.stop()

--- a/app/controllers/CorporationTaxRegistrationController.scala
+++ b/app/controllers/CorporationTaxRegistrationController.scala
@@ -17,9 +17,8 @@
 package controllers
 
 import javax.inject.Inject
-
 import auth._
-import models.{AcknowledgementReferences, CHROAddress, ConfirmationReferences, CorporationTaxRegistrationRequest}
+import models._
 import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.mvc.{Action, AnyContent, AnyContentAsJson, Request}
 import repositories.{CorporationTaxRegistrationMongoRepository, Repositories}
@@ -172,7 +171,7 @@ trait CorporationTaxRegistrationController extends BaseController with Authorise
     implicit request =>
       withJsonBody[CHROAddress] { body =>
         Future.successful(ctService.convertROToPPOBAddress(body) match {
-          case Some(ppob) => Ok(Json.toJson(ppob))
+          case Some(ppob) => Ok(Json.toJson(ppob)(PPOBAddress.writes))
           case _          => BadRequest
         })
       }

--- a/app/models/validation/BaseJsonFormatting.scala
+++ b/app/models/validation/BaseJsonFormatting.scala
@@ -33,7 +33,7 @@ trait BaseJsonFormatting {
 
   val dateTimePattern = "yyyy-MM-dd"
 
-  def length(maxLen: Int, minLen: Int = 1): Reads[String] = maxLength[String](maxLen) keepAnd minLength[String](minLen)
+  def length(maxLen: Int, minLen: Int = 1)(implicit reads: Reads[String]): Reads[String] = maxLength[String](maxLen) keepAnd minLength[String](minLen)
 
   def readToFmt(rds: Reads[String])(implicit wts: Writes[String]): Format[String] = Format(rds, wts)
 

--- a/app/utils/StringNormaliser.scala
+++ b/app/utils/StringNormaliser.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import java.text.Normalizer.Form
+import java.text.Normalizer._
+
+import models.validation.APIValidation
+
+import scala.util.matching.Regex
+
+object StringNormaliser {
+  val specialCharacterConverts = Map('æ' -> "ae", 'Æ' -> "AE", 'œ' -> "oe", 'Œ' -> "OE", 'ß' -> "ss", 'ø' -> "o", 'Ø' -> "O")
+  def normaliseString(string : String, charFilter : Regex) : String = {
+    normalize(string, Form.NFKD)
+      .replaceAll("\\p{M}", "")
+      .trim
+      .map(char => specialCharacterConverts.getOrElse(char, char))
+      .mkString
+      .filter(c => c.toString matches charFilter.regex)
+  }
+}

--- a/it/api/CompanyDetailsApiISpec.scala
+++ b/it/api/CompanyDetailsApiISpec.scala
@@ -1,0 +1,141 @@
+
+package api
+
+import controllers.routes
+import itutil.{IntegrationSpecBase, LoginStub, WiremockHelper}
+import models._
+import play.api.Application
+import play.api.http.HeaderNames
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.{JsObject, Json}
+import play.api.libs.ws.WS
+import play.modules.reactivemongo.MongoDbConnection
+import reactivemongo.api.commands.WriteResult
+import repositories.{CorporationTaxRegistrationMongoRepository, SequenceMongoRepository}
+import uk.gov.hmrc.http.{HeaderNames => GovHeaderNames}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class CompanyDetailsApiISpec extends IntegrationSpecBase with LoginStub  {
+  val mockHost = WiremockHelper.wiremockHost
+  val mockPort = WiremockHelper.wiremockPort
+  val mockUrl = s"http://$mockHost:$mockPort"
+
+  val additionalConfiguration = Map(
+    "auditing.consumer.baseUri.host" -> s"$mockHost",
+    "auditing.consumer.baseUri.port" -> s"$mockPort",
+    "microservice.services.auth.host" -> s"$mockHost",
+    "microservice.services.auth.port" -> s"$mockPort",
+    "microservice.services.business-registration.host" -> s"$mockHost",
+    "microservice.services.business-registration.port" -> s"$mockPort",
+    "microservice.services.email.sendEmailURL" -> s"$mockUrl/hmrc/email",
+    "microservice.services.address-line-4-fix.regId" -> s"999",
+    "microservice.services.address-line-4-fix.address-line-4" -> s"dGVzdEFMNA==",
+    "microservice.services.check-submission-job.schedule.blockage-logging-day" -> s"MON,TUE,WED,THU,FRI",
+    "microservice.services.check-submission-job.schedule.blockage-logging-time" -> s"00:00:00_01:00:00",
+    "microservice.services.des-service.host" -> s"$mockHost",
+    "microservice.services.des-service.port" -> s"$mockPort",
+    "microservice.services.des-service.url" -> s"$mockUrl/business-registration/corporation-tax",
+    "microservice.services.des-service.environment" -> "local",
+    "microservice.services.des-service.authorization-token" -> "testAuthToken",
+    "microservice.services.des-topup-service.host" -> mockHost,
+    "microservice.services.des-topup-service.port" -> mockPort
+  )
+  override implicit lazy val app: Application = new GuiceApplicationBuilder()
+    .configure(additionalConfiguration)
+    .build()
+
+  private def client(path: String) = WS.url(s"http://localhost:$port/company-registration/corporation-tax-registration$path")
+    .withFollowRedirects(false)
+    .withHeaders("Content-Type"->"application/json")
+    .withHeaders(HeaderNames.SET_COOKIE -> getSessionCookie())
+    .withHeaders(GovHeaderNames.xSessionId -> SessionId)
+
+  class Setup extends MongoDbConnection {
+    val ctRepository = new CorporationTaxRegistrationMongoRepository(db)
+    val seqRepo = new SequenceMongoRepository(db)
+
+    await(ctRepository.drop)
+    await(ctRepository.ensureIndexes)
+
+    await(seqRepo.drop)
+    await(seqRepo.ensureIndexes)
+
+    System.clearProperty("feature.registerInterest")
+    System.clearProperty("feature.etmpHoldingPen")
+
+    def setupCTRegistration(reg: CorporationTaxRegistration): WriteResult = ctRepository.insert(reg)
+
+  }
+  val regId = "reg-id-12345"
+  val internalId = "int-id-12345"
+  val transId = "trans-id-2345"
+  val defaultCHROAddress = CHROAddress("Premises", "Line 1", Some("Line 2"), "Country", "Locality", Some("PO box"), Some("Post code"), Some("Region"))
+  val defaulPPOBAddress = PPOB("MANUAL", Some(PPOBAddress("10 tæst beet","test tØwn",Some("tæst area"),Some("tæst coûnty"),Some("XX1 1ØZ"),Some("test coûntry"),None,"txid")))
+  val nonNormalisablePPOBAddress = PPOB("MANUAL", Some(PPOBAddress("ææ ææææ æææææ","abcdcgasfgfags fgafsggafgææ",Some("æææææææ æææææ"),Some("tæst coûnty"),Some("XX1 1ØZ"),Some("test coûntry"),None,"txid")))
+  val normalisedDefaultPPOBAddress = PPOB("MANUAL", Some(PPOBAddress("10 taest beet","test tOwn",Some("taest area"),Some("taest county"),Some("XX1 1OZ"),Some("test country"),None,"txid")))
+  val validPPOBAddress = PPOB("MANUAL", Some(PPOBAddress("10 test beet","test tOwn",Some("test area"),Some("test county"),Some("XX1 1OZ"),Some("test country"),None,"txid")))
+  val ctDoc = CorporationTaxRegistration(internalId, regId, RegistrationStatus.DRAFT, formCreationTimestamp = "foo", language = "bar")
+  val validCompanyDetails = CompanyDetails("testCompanyName", defaultCHROAddress, defaulPPOBAddress, "testJurisdiction")
+  val ctDocWithCompDetails: CorporationTaxRegistration = ctDoc.copy(companyDetails = Some(validCompanyDetails))
+
+  val validCompanyDetailsResponse: CompanyDetails => JsObject = {
+    Json.toJson(_).as[JsObject] ++ Json.obj(
+      "tradingDetails" -> TradingDetails(),
+      "links" -> Json.obj(
+        "self" -> routes.CompanyDetailsController.retrieveCompanyDetails(regId).url,
+        "registration" -> routes.CorporationTaxRegistrationController.retrieveCorporationTaxRegistration(regId).url
+    ))
+  }
+
+  val validPostData: PPOB => JsObject = address => Json.obj(
+      "companyName" -> "testCompanyName",
+      "cHROAddress" -> Json.toJson(defaultCHROAddress),
+      "pPOBAddress" -> Json.toJson(address),
+      "jurisdiction" -> "testJurisdiction"
+    )
+
+  s"GET ${controllers.routes.CompanyDetailsController.retrieveCompanyDetails(regId).url}" should {
+
+    "return 404 when company details does not exist" in new Setup {
+      stubAuthorise(internalId)
+      setupCTRegistration(ctDoc)
+      val response = await(client(s"/$regId/company-details").get())
+      response.status shouldBe 404
+    }
+
+    "return 200 when company details exists" in new Setup {
+      stubAuthorise(internalId)
+      setupCTRegistration(ctDocWithCompDetails)
+      val response = await(client(s"/$regId/company-details").get())
+      response.status shouldBe 200
+      response.json shouldBe validCompanyDetailsResponse(ctDocWithCompDetails.companyDetails.get)
+    }
+  }
+
+  s"POST ${controllers.routes.CompanyDetailsController.updateCompanyDetails(regId).url}" should {
+
+    "return 200 and normalise ppob with invalid characters" in new Setup {
+      stubAuthorise(internalId)
+      setupCTRegistration(ctDoc)
+
+      val response = await(client(s"/$regId/company-details").put(validPostData(defaulPPOBAddress).toString()))
+      response.status shouldBe 200
+      response.json shouldBe validCompanyDetailsResponse(ctDocWithCompDetails.companyDetails.get.copy(ppob = normalisedDefaultPPOBAddress))
+    }
+
+    "return 200 with no normalising needed with an address type of manual" in new Setup {
+      stubAuthorise(internalId)
+      setupCTRegistration(ctDocWithCompDetails)
+      val response = await(client(s"/$regId/company-details").put(validPostData(validPPOBAddress).toString()))
+      response.status shouldBe 200
+      response.json shouldBe validCompanyDetailsResponse(ctDocWithCompDetails.companyDetails.get.copy(ppob = validPPOBAddress))
+    }
+    "return 400 with unnormalisable ppob" in new Setup {
+      stubAuthorise(internalId)
+      setupCTRegistration(ctDocWithCompDetails)
+      val response = await(client(s"/$regId/company-details").put(validPostData(nonNormalisablePPOBAddress).toString()))
+      response.status shouldBe 400
+    }
+  }
+}

--- a/test/fixtures/CompanyDetailsFixture.scala
+++ b/test/fixtures/CompanyDetailsFixture.scala
@@ -67,6 +67,33 @@ trait CompanyDetailsFixture {
     "testJurisdiction"
   )
 
+  lazy val validCompanyDetailsNormalisableAddress = CompanyDetails(
+    "testCompanyName",
+    CHROAddress(
+      "Premises",
+      "Line 1",
+      Some("Line 2"),
+      "Country",
+      "Locality",
+      Some("PO box"),
+      Some("Post code"),
+      Some("Region")
+    ),
+    PPOB(
+      "MANUAL",
+      Some(PPOBAddress(
+        "10 test æet",
+        "test tØwn",
+        Some("tæst area"),
+        Some("tæst coûnty"),
+        Some("XX1 1ØZ"),
+        Some("test country"),
+        None,
+        "txid"
+      ))),
+    "testJurisdiction"
+  )
+
   import CompanyDetailsResponse.buildLinks
   lazy val validCompanyDetailsResponse = CompanyDetailsResponse(
     companyName = validCompanyDetails.companyName,

--- a/test/models/CorporationTaxRegistrationSpec.scala
+++ b/test/models/CorporationTaxRegistrationSpec.scala
@@ -97,14 +97,11 @@ class CorporationTaxRegistrationSpec extends UnitSpec with JsonFormatValidation 
         """.stripMargin)
 
           "fail on company name" when {
-
-
             "it is too long" in {
                 val longName = List.fill(161)('a').mkString
                 val json = tstJson(longName)
 
                   val result = Json.fromJson[CompanyDetails](json)
-
                   shouldHaveErrors(result, JsPath() \ "companyName", Seq(ValidationError("Invalid company name")))
               }
             "it is too short" in {

--- a/test/utils/StringNormaliserSpec.scala
+++ b/test/utils/StringNormaliserSpec.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import uk.gov.hmrc.play.test.UnitSpec
+
+class StringNormaliserSpec extends UnitSpec {
+
+  "normaliseString" should {
+    Seq(
+      ("ZZ1 1ZZ", "[A-Za-z0-9 ]", "ZZ1 1ZZ"),
+      ("ZZ1 1ZZ", "[A-Za-z0-9]", "ZZ11ZZ"),
+      ("ZZ1 1ZZ", "[a-z0-9 ]", "1 1"),
+      ("My nænæ is juúst like yØû", "[A-Za-z0-9 ]", "My naenae is juust like yOu"),
+      ("My nænæ is just like you", "[0-9]", "")
+    ).foreach{
+      case (string, filter, result) => s"return '$result' when '$string' is passed in using regex '$filter'" in {
+        StringNormaliser.normaliseString(string, filter.r) shouldBe result
+      }
+    }
+  }
+}


### PR DESCRIPTION
 to handle saving ALF Addresses which contain characters that do not match our regex

[SCRS-11761] Fix Blowing up when ALF returned with invalid address

**Bug fix**

normalised all addresses when submitted to the backend

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date 
