### PR TITLE
SCRS-11761-fix added .take to string after normalisation

### DIFF
--- a/app/models/validation/APIValidation.scala
+++ b/app/models/validation/APIValidation.scala
@@ -118,21 +118,21 @@ trait AddressValidator {
   val postCodeInvert = regexWrap("[A-Z0-9 ]")
   val countryInvert = regexWrap("[A-Za-z0-9 ]")
 
-  def normaliseStringReads(regex:Regex)(implicit implReads: Reads[String]): Reads[String] = new Reads[String] {
+  def normaliseStringReads(regex:Regex, amountToTake: Int)(implicit implReads: Reads[String]): Reads[String] = new Reads[String] {
     override def reads(json: JsValue): JsResult[String] = {
       implReads.reads(json).flatMap { theString =>
         val string = StringNormaliser.normaliseString(theString, regex)
         if (theString.nonEmpty && string.isEmpty) {
           JsError("error.not.normalisable")
         } else {
-          JsSuccess(string)
+          JsSuccess(string.take(amountToTake))
         }
       }
     }
   }
 
   def chainedNormaliseReads(regex: Regex, maxLength: Int) = {
-    length(maxLength)(normaliseStringReads(regex))
+    length(maxLength)(normaliseStringReads(regex, maxLength))
   }
 
   val lineValidator = readToFmt(pattern(linePattern)(chainedNormaliseReads(lineInvert, 27)))

--- a/app/models/validation/BaseJsonFormatting.scala
+++ b/app/models/validation/BaseJsonFormatting.scala
@@ -35,6 +35,8 @@ trait BaseJsonFormatting {
 
   def length(maxLen: Int, minLen: Int = 1)(implicit reads: Reads[String]): Reads[String] = maxLength[String](maxLen) keepAnd minLength[String](minLen)
 
+
+
   def readToFmt(rds: Reads[String])(implicit wts: Writes[String]): Format[String] = Format(rds, wts)
 
   def digitLength(minLength: Int, maxLength: Int)(implicit wts: Writes[String]):Format[String] = {

--- a/it/api/CompanyDetailsApiISpec.scala
+++ b/it/api/CompanyDetailsApiISpec.scala
@@ -72,7 +72,8 @@ class CompanyDetailsApiISpec extends IntegrationSpecBase with LoginStub  {
   val transId = "trans-id-2345"
   val defaultCHROAddress = CHROAddress("Premises", "Line 1", Some("Line 2"), "Country", "Locality", Some("PO box"), Some("Post code"), Some("Region"))
   val defaulPPOBAddress = PPOB("MANUAL", Some(PPOBAddress("10 tæst beet","test tØwn",Some("tæst area"),Some("tæst coûnty"),Some("XX1 1ØZ"),Some("test coûntry"),None,"txid")))
-  val nonNormalisablePPOBAddress = PPOB("MANUAL", Some(PPOBAddress("ææ ææææ æææææ","abcdcgasfgfags fgafsggafgææ",Some("æææææææ æææææ"),Some("tæst coûnty"),Some("XX1 1ØZ"),Some("test coûntry"),None,"txid")))
+  val nonNormalisedAddressMaxLengthCheck = PPOB("MANUAL", Some(PPOBAddress("ææ ææææ æææææ","abcdcgasfgfags fgafsggafgææ",Some("æææææææ æææææ"),Some("tæst coûnty"),Some("XX1 1ØZ"),Some("test coûntry"),None,"txid")))
+  val normalisedAddressMaxLengthCheck = PPOB("MANUAL", Some(PPOBAddress("aeae aeaeaeae aeaeaeaeae","abcdcgasfgfags fgafsggafgae",Some("aeaeaeaeaeaeae aeaeaeaeae"),Some("taest county"),Some("XX1 1OZ"),Some("test country"),None,"txid")))
   val normalisedDefaultPPOBAddress = PPOB("MANUAL", Some(PPOBAddress("10 taest beet","test tOwn",Some("taest area"),Some("taest county"),Some("XX1 1OZ"),Some("test country"),None,"txid")))
   val validPPOBAddress = PPOB("MANUAL", Some(PPOBAddress("10 test beet","test tOwn",Some("test area"),Some("test county"),Some("XX1 1OZ"),Some("test country"),None,"txid")))
   val ctDoc = CorporationTaxRegistration(internalId, regId, RegistrationStatus.DRAFT, formCreationTimestamp = "foo", language = "bar")
@@ -131,11 +132,12 @@ class CompanyDetailsApiISpec extends IntegrationSpecBase with LoginStub  {
       response.status shouldBe 200
       response.json shouldBe validCompanyDetailsResponse(ctDocWithCompDetails.companyDetails.get.copy(ppob = validPPOBAddress))
     }
-    "return 400 with unnormalisable ppob" in new Setup {
+    "return 200 with unnormalisable ppob because characters are trimmed to max length" in new Setup {
       stubAuthorise(internalId)
       setupCTRegistration(ctDocWithCompDetails)
-      val response = await(client(s"/$regId/company-details").put(validPostData(nonNormalisablePPOBAddress).toString()))
-      response.status shouldBe 400
+      val response = await(client(s"/$regId/company-details").put(validPostData(nonNormalisedAddressMaxLengthCheck).toString()))
+      response.status shouldBe 200
+      response.json shouldBe validCompanyDetailsResponse(ctDocWithCompDetails.companyDetails.get.copy(ppob = normalisedAddressMaxLengthCheck))
     }
   }
 }

--- a/test/models/PPOBAddressSpec.scala
+++ b/test/models/PPOBAddressSpec.scala
@@ -71,12 +71,13 @@ class PPOBAddressSpec extends UnitSpec with JsonFormatValidation {
       shouldHaveErrors(result, JsPath() \ "addressLine1", Seq(ValidationError("error.minLength", 1)))
     }
 
-    "fail to be read from JSON if line1 is longer than 27 characters" in {
-      val json = j(line1="1234567890123456789012345678")
-
+    "be able parse to be read from JSON if line1 is longer than 27 characters returning 27 characters" in {
+      val line1 = "1234567890123456789012345678"
+      val json = j(line1="1234567890123456789012345678",pc=Some("ZZ1 1ZZ"))
+      val expected = PPOBAddress(line1.take(27), "2", None, Some("4"), Some("ZZ1 1ZZ"), None, None, "txid")
       val result = Json.parse(json).validate[PPOBAddress](PPOBAddress.normalisingReads(APIValidation))
 
-      shouldHaveErrors(result, JsPath() \ "addressLine1", Seq(ValidationError("error.maxLength", 27)))
+      shouldBeSuccess(expected, result)
     }
   }
 
@@ -109,12 +110,14 @@ class PPOBAddressSpec extends UnitSpec with JsonFormatValidation {
       shouldBeSuccess(expected, result)
     }
 
-    "Fail if 19chars in Address Line 4" in {
+    "be able to parse if 19chars in Address Line 4, returning 18 characters" in {
       val line3 = Some("Line3")
       val line4 = Some("19charsinaddLine4xx")
       val json = j(line3=line3, line4=line4, country=Some("c"), uprn=Some("xxx"))
+      val expected = PPOBAddress("1", "2", line3, Some("19charsinaddLine4x"), None, Some("c"), Some("xxx"), "txid")
       val result = Json.parse(json).validate[PPOBAddress](PPOBAddress.normalisingReads(APIValidation))
-      shouldHaveErrors(result, JsPath() \ "addressLine4", Seq(ValidationError("error.maxLength", 18)))
+
+      shouldBeSuccess(expected, result)
     }
 
     "fail to be read from JSON if line2 is empty string" in {
@@ -125,17 +128,13 @@ class PPOBAddressSpec extends UnitSpec with JsonFormatValidation {
       shouldHaveErrors(result, JsPath() \ "addressLine3", Seq(ValidationError("error.minLength", 1)))
     }
 
-    "fail to be read from JSON if line2 is longer than 27 characters" in {
-      val json = j(line3=Some("1234567890123456789012345678"), country=Some("c"))
-
+    "be able to parse from JSON if line2 is longer than 27 characters returning 27 characters" in {
+      val line3 = Some("1234567890123456789012345678")
+      val json = j(line3=line3, country=Some("c"))
+      val expected = PPOBAddress("1", "2", line3.map(_.take(27)), Some("4"), None, Some("c"), None, "txid")
       val result = Json.parse(json).validate[PPOBAddress](PPOBAddress.normalisingReads(APIValidation))
 
-      shouldHaveErrors(result, JsPath() \ "addressLine3", Seq(ValidationError("error.maxLength", 27)))
-    }
-    "fail with max length error not error.pattern when characters are normalised to be greater than max length of field" in {
-      val json = j(line3=Some("abcdcgasfgfags fgafsggafgææ"), country=Some("c"))
-      val result = Json.parse(json).validate[PPOBAddress](PPOBAddress.normalisingReads(APIValidation))
-      shouldHaveErrors(result, JsPath() \ "addressLine3", Seq(ValidationError("error.maxLength", 27)))
+      shouldBeSuccess(expected, result)
     }
   }
 


### PR DESCRIPTION
# SCRS-11761

**bug fix**

take the maximum length characters used in validation. this is to counter when ALFs data is normalised and becomes longer than the original length

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date 
