### PR TITLE
SCRS-11897 - added startup job to find how many rejected docs we have…

### DIFF
--- a/app/config/microserviceGlobal.scala
+++ b/app/config/microserviceGlobal.scala
@@ -216,4 +216,10 @@ class AppStartupJobs @Inject()(config: Configuration,
       }
     }
   }
+
+  def retrieveCountOfInvalidRejections() = {
+    ctRepo.retrieveCountOfInvalidRejections() map { count =>
+      Logger.info(s"[InvalidRejections] found $count document(s)")
+    }
+  }
 }

--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -12,7 +12,6 @@ trait MicroService {
   import uk.gov.hmrc.SbtAutoBuildPlugin
   import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin
   import uk.gov.hmrc.versioning.SbtGitVersioning
-  import TestPhases._
   import play.sbt.routes.RoutesKeys.routesGenerator
 
   val appName: String
@@ -54,24 +53,7 @@ trait MicroService {
     )
     .configs(IntegrationTest)
     .settings(inConfig(IntegrationTest)(Defaults.itSettings): _*)
-    .settings(
-      Keys.fork in IntegrationTest := false,
-      unmanagedSourceDirectories in IntegrationTest <<= (baseDirectory in IntegrationTest)(base => Seq(base / "it")),
-      addTestReportOption(IntegrationTest, "int-test-reports"),
-      testGrouping in IntegrationTest := oneForkedJvmPerTest((definedTests in IntegrationTest).value),
-      parallelExecution in IntegrationTest := false)
-    .settings(
-       resolvers += Resolver.bintrayRepo("hmrc", "releases"),
-       resolvers += Resolver.jcenterRepo
-       )
-}
-
-private object TestPhases {
-
-  def oneForkedJvmPerTest(tests: Seq[TestDefinition]) =
-    tests map {
-      test => new Group(test.name, Seq(test), SubProcess(ForkOptions(runJVMOptions = Seq("-Dtest.name=" + test.name))))
-    }
+    .settings(integrationTestSettings())
 }
 
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,11 +2,11 @@ resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.co
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.8.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.12.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.10.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.1.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.12")
 

--- a/test/config/AppStartupJobsSpec.scala
+++ b/test/config/AppStartupJobsSpec.scala
@@ -139,4 +139,18 @@ class AppStartupJobsSpec extends UnitSpec with MockitoSugar with LogCapturing
     }
 
   }
+  "retrieveCount of invalid rejections" in new Setup {
+    when(mockCTRepository.retrieveCountOfInvalidRejections).thenReturn(Future.successful(1))
+
+    withCaptureOfLoggingFrom(Logger){ logEvents =>
+      eventually {
+        await(appStartupJobs.retrieveCountOfInvalidRejections)
+        val expectedLogs = List(
+          "[InvalidRejections] found 1 document(s)"
+        )
+
+        expectedLogs.diff(logEvents.map(_.getMessage)) shouldBe List.empty
+      }
+    }
+  }
 }


### PR DESCRIPTION
… that are in a certain state, plus minor dep uplift

11897

startup mongo job does a count of rejected docs in certain state

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date 
