### PR TITLE
SCRS-11805 Added admin API endpoints to fetch/amend a session ID

### DIFF
--- a/app/audit/AdminSessionIDEvent.scala
+++ b/app/audit/AdminSessionIDEvent.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit
+
+import play.api.libs.json.{JsObject, Json}
+import uk.gov.hmrc.http.HeaderCarrier
+
+class AdminSessionIDEvent(timestamp: JsObject, strideUsername: String, sessionIdData : JsObject, oldId : String)(implicit hc: HeaderCarrier)
+  extends RegistrationAuditEvent(
+    auditType = "adminSessionID",
+    transactionName =  Some("admin-session-id"),
+    detail = {
+      val strideUser = Json.obj("strideUserId" -> strideUsername)
+      val oldSessionId = Json.obj("oldSessionId" -> oldId)
+      timestamp ++ strideUser ++ sessionIdData ++ oldSessionId
+    },
+    tagSet = TagSet.REQUEST_ONLY)

--- a/app/models/CorporationTaxRegistration.scala
+++ b/app/models/CorporationTaxRegistration.scala
@@ -352,6 +352,18 @@ object HO6RegistrationInformation {
     )(unlift(HO6RegistrationInformation.unapply))
 }
 
+case class SessionIdData(sessionId: Option[String],
+                         companyName: Option[String],
+                         ackRef: Option[String])
+
+object SessionIdData {
+  implicit val writes = (
+    (__ \ "sessionId").writeNullable[String] and
+      (__ \ "companyName").writeNullable[String] and
+      (__ \ "ackRef").writeNullable[String]
+    )(unlift(SessionIdData.unapply))
+}
+
 
 case class SessionIds(sessionId: String,
                       credId: String)

--- a/app/services/CorporationTaxRegistrationService.scala
+++ b/app/services/CorporationTaxRegistrationService.scala
@@ -45,12 +45,12 @@ import scala.util.control.NoStackTrace
 import scala.util.matching.Regex
 
 class CorporationTaxRegistrationServiceImpl @Inject()(
-        val submissionCheckAPIConnector: IncorporationCheckAPIConnector,
-        val brConnector: BusinessRegistrationConnector,
-        val desConnector: DesConnector,
-        val incorpInfoConnector: IncorporationInformationConnector,
-        val repositories: Repositories
-      ) extends CorporationTaxRegistrationService {
+                                                       val submissionCheckAPIConnector: IncorporationCheckAPIConnector,
+                                                       val brConnector: BusinessRegistrationConnector,
+                                                       val desConnector: DesConnector,
+                                                       val incorpInfoConnector: IncorporationInformationConnector,
+                                                       val repositories: Repositories
+                                                     ) extends CorporationTaxRegistrationService {
 
   val cTRegistrationRepository: CorporationTaxRegistrationMongoRepository = repositories.cTRepository
   val sequenceRepository: SequenceMongoRepository = repositories.sequenceRepository
@@ -96,9 +96,9 @@ trait CorporationTaxRegistrationService extends DateHelper {
   def updateCTRecordWithAckRefs(ackRef: String, etmpNotification: AcknowledgementReferences): Future[Option[CorporationTaxRegistration]] = {
     cTRegistrationRepository.retrieveByAckRef(ackRef) flatMap {
       case Some(record) =>
-          cTRegistrationRepository.updateCTRecordWithAcknowledgments(ackRef, record.copy(acknowledgementReferences = Some(etmpNotification), status = RegistrationStatus.ACKNOWLEDGED)) map {
-            _ => Some(record)
-          }
+        cTRegistrationRepository.updateCTRecordWithAcknowledgments(ackRef, record.copy(acknowledgementReferences = Some(etmpNotification), status = RegistrationStatus.ACKNOWLEDGED)) map {
+          _ => Some(record)
+        }
       case None =>
         Logger.info(s"[CorporationTaxRegistrationService] - [updateCTRecordWithAckRefs] : No record could not be found using this ackref")
         Future.successful(None)
@@ -160,10 +160,10 @@ trait CorporationTaxRegistrationService extends DateHelper {
       case Some(cr) =>
         Future.successful(cr)
     } flatMap { cr =>
-        sendPartialSubmission(rID, authProvId, cr).ifM(
-          ifTrue = Future.successful(cr),
-          ifFalse = throw new RuntimeException("Document did not update successfully")
-        )
+      sendPartialSubmission(rID, authProvId, cr).ifM(
+        ifTrue = Future.successful(cr),
+        ifFalse = throw new RuntimeException("Document did not update successfully")
+      )
     }
   }
 

--- a/app/utils/AlertLogging.scala
+++ b/app/utils/AlertLogging.scala
@@ -42,7 +42,7 @@ trait AlertLogging {
 
   def pagerduty(key: PagerDutyKeys.Value, message: Option[String] = None) {
     val log = s"${key.toString}${message.fold("")(msg => s" - $msg")}"
-    if(inWorkingHours) Logger.error(log) else Logger.info(log)
+    if (inWorkingHours) Logger.error(log) else Logger.info(log)
   }
 
   def inWorkingHours: Boolean = isLoggingDay && isBetweenLoggingTimes
@@ -51,7 +51,7 @@ trait AlertLogging {
 
   private[utils] def now: LocalTime = getCurrentTime
 
-  private[utils] def ifInWorkingHours(alert: => Unit): Unit = if(inWorkingHours) alert else ()
+  private[utils] def ifInWorkingHours(alert: => Unit): Unit = if (inWorkingHours) alert else ()
 
   private[utils] def isLoggingDay = loggingDays.split(",").contains(today)
 

--- a/conf/admin.routes
+++ b/conf/admin.routes
@@ -1,5 +1,9 @@
 
 GET        /fetch-ho6-registration-information/:registrationId        @controllers.admin.AdminController.fetchHO6RegistrationInformation(registrationId)
+
+GET        /session-id/:registrationId                                @controllers.admin.AdminController.fetchSessionIDData(registrationId)
+POST       /session-id/:registrationId                                @controllers.admin.AdminController.updateSessionId(registrationId)
+
 GET        /migrate-held-submissions                                  @controllers.admin.AdminController.migrateHeldSubmissions
 POST       /update-confirmation-references                            @controllers.admin.AdminController.updateConfirmationReferences
 


### PR DESCRIPTION
# SCRS-11805 Added admin API endpoints to amend a session ID

**New feature**

2 new endpoints for admin frontend - one to fetch the session id associated data, one to amend a session id. These endpoints both key on registration/journey ID.

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date 
