### PR TITLE
SCRS-12778 updated submissionservice to save conf ref when payment re…

### DIFF
--- a/app/controllers/HeldController.scala
+++ b/app/controllers/HeldController.scala
@@ -41,7 +41,7 @@ trait HeldController extends BaseController with AuthorisedActions {
   def fetchHeldSubmissionTime(regId: String): Action[AnyContent] = AuthenticatedAction.async {
     implicit request =>
       resource.getExistingRegistration(regId) map { doc =>
-          Ok(Json.toJson(doc.heldTimestamp))
+        doc.heldTimestamp.fold(NotFound(""))(date => Ok(Json.toJson(date)))
       }
   }
 

--- a/app/services/SubmissionService.scala
+++ b/app/services/SubmissionService.scala
@@ -111,13 +111,14 @@ trait SubmissionService extends DateHelper {
         } yield updatedRefs
 
       case Some(cr) if confirmationRefsAndPaymentRefsAreEmpty(cr) =>
-        Future.successful(cr.copy(paymentReference = refs.paymentReference, paymentAmount = refs.paymentAmount))
+        storeConfirmationReferencesAndUpdateStatus(rID, cr.copy(paymentReference = refs.paymentReference, paymentAmount = refs.paymentAmount), None)
 
       case Some(cr) =>
         Future.successful(cr)
 
     }
   }
+
 
   private[services] def storeConfirmationReferencesAndUpdateStatus(regId: String, refs: ConfirmationReferences, status: Option[String]): Future[ConfirmationReferences] = {
     status.fold(cTRegistrationRepository.updateConfirmationReferences(regId, refs))(cTRegistrationRepository.updateConfirmationReferencesAndUpdateStatus(regId, refs, _)) map {

--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -24,14 +24,14 @@ private object AppDependencies {
   import play.sbt.PlayImport._
 
   private val microserviceBootstrapVersion = "8.7.0"
-  private val domainVersion = "5.2.0"
+  private val domainVersion = "5.3.0"
   private val hmrcTestVersion = "3.2.0"
   private val reactiveMongoVersion = "6.2.0"
   private val mockitoVersion = "2.13.0"
   private val scalatestPlusPlayVersion = "2.0.0"
   private val playSchedulingVersion = "4.1.0"
   private val mongoLockVersion = "5.1.0"
-  private val authClientVersion = "2.17.0-play-25"
+  private val authClientVersion = "2.19.0-play-25"
 
   val compile = Seq(
     ws,

--- a/test/controllers/HeldControllerSpec.scala
+++ b/test/controllers/HeldControllerSpec.scala
@@ -86,6 +86,16 @@ class HeldControllerSpec extends BaseSpec with AuthorisationMocks {
       status(result) shouldBe OK
       contentAsString(result) shouldBe s"${now.getMillis}"
     }
+    "return 404 If no date exists" in new Setup {
+      mockAuthorise()
+
+      when(mockResource.getExistingRegistration(ArgumentMatchers.any()))
+        .thenReturn(Future.successful(doc(None)))
+
+      val result = await(controller.fetchHeldSubmissionTime(regId)(FakeRequest()))
+      status(result) shouldBe 404
+      contentAsString(result) shouldBe ""
+    }
 
     "return an exception if experieced" in new Setup {
       mockAuthorise()


### PR DESCRIPTION
Updates SubmissionService method prepareDocumentForSubmission to save conf refs when payment refs are empty, also added three unit tests for each outcome of the method. 

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date (where able)
