### PR TITLE
SCRS-12859 added new endpoint to CR which saves the TXid and generates the ackref earlier on in the journey also amended log message of stale documents job to be more descriptive

### DIFF
--- a/app/models/CorporationTaxRegistration.scala
+++ b/app/models/CorporationTaxRegistration.scala
@@ -153,6 +153,16 @@ object ConfirmationReferences {
   implicit val apiFormat = format(APIValidation)
 }
 
+object ElementsFromH02Reads {
+  val reads = new Reads[String] {
+    override def reads(json: JsValue): JsResult[String] =
+      for {
+        obj <- json.validate[JsObject]
+        str <- (obj \ "transaction_id").validate[String]
+      } yield  str
+  }
+}
+
 case class CompanyDetails(companyName: String,
                           registeredOffice: CHROAddress,
                           ppob: PPOB,

--- a/app/services/CompanyDetailsService.scala
+++ b/app/services/CompanyDetailsService.scala
@@ -17,19 +17,41 @@
 package services
 
 import javax.inject.Inject
-
-import models.CompanyDetails
+import models.{CompanyDetails, ConfirmationReferences}
+import play.api.Logger
+import play.api.libs.json.{JsObject, Json}
 import repositories.{CorporationTaxRegistrationMongoRepository, Repositories}
+import scala.concurrent.ExecutionContext.Implicits.global
 
 import scala.concurrent.Future
 
-class CompanyDetailsServiceImpl @Inject()(val repositories: Repositories) extends CompanyDetailsService {
+class CompanyDetailsServiceImpl @Inject()(val repositories: Repositories,
+                                          val submissionService: SubmissionService) extends CompanyDetailsService {
   lazy val corporationTaxRegistrationRepository = repositories.cTRepository
 }
-
 trait CompanyDetailsService {
 
+  val submissionService: SubmissionService
+
   val corporationTaxRegistrationRepository : CorporationTaxRegistrationMongoRepository
+
+  private[services] def convertAckRefToJsObject(ref: String): JsObject = Json.obj("acknowledgement-reference" -> ref)
+
+  def saveTxIdAndAckRef(registrationId:String, txid:String): Future[SaveTxIdRes] = {
+    corporationTaxRegistrationRepository.retrieveConfirmationReferences(registrationId).flatMap {
+      optConfRefs => optConfRefs.fold[Future[SaveTxIdRes]] {
+        submissionService.generateAckRef.flatMap { ackRef =>
+          val confirmationRefsToBeAddedToCTRecord = ConfirmationReferences(ackRef, txid, None, None)
+          corporationTaxRegistrationRepository.updateConfirmationReferences(registrationId, confirmationRefsToBeAddedToCTRecord)
+            .map { _ =>
+              DidNotExistInCRNowSaved(convertAckRefToJsObject(ackRef))
+            }
+        }
+      }(confReferences => Future.successful(ExistedInCRAlready(convertAckRefToJsObject(confReferences.acknowledgementReference))))
+    }.recoverWith {
+      case e: Exception => Future.successful(SomethingWentWrongWhenSaving(e,registrationId,txid))
+    }
+  }
 
   def retrieveCompanyDetails(registrationID: String): Future[Option[CompanyDetails]] = {
     corporationTaxRegistrationRepository.retrieveCompanyDetails(registrationID)
@@ -38,4 +60,13 @@ trait CompanyDetailsService {
   def updateCompanyDetails(registrationID: String, companyDetails: CompanyDetails): Future[Option[CompanyDetails]] = {
     corporationTaxRegistrationRepository.updateCompanyDetails(registrationID, companyDetails)
   }
+}
+
+sealed trait SaveTxIdRes
+case class DidNotExistInCRNowSaved(js:JsObject) extends SaveTxIdRes {
+  Logger.info("Saved TxId after H02")
+}
+case class ExistedInCRAlready(js:JsObject) extends SaveTxIdRes
+case class SomethingWentWrongWhenSaving(ex:Exception, regId:String, txId:String) extends SaveTxIdRes {
+  Logger.warn(s"Something went wrong when calling the function that saves txid and gens ackreg with ex: ${ex.getMessage} for regId: $regId and txId: $txId")
 }

--- a/app/services/SubmissionService.scala
+++ b/app/services/SubmissionService.scala
@@ -31,6 +31,7 @@ import play.api.mvc.{AnyContent, Request}
 import repositories.{CorporationTaxRegistrationMongoRepository, CorporationTaxRegistrationRepository, Repositories, SequenceRepository}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
+import utils.PagerDutyKeys
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -63,6 +64,7 @@ trait SubmissionService extends DateHelper {
                       (implicit hc: HeaderCarrier, req: Request[AnyContent]): Future[ConfirmationReferences] = {
     cTRegistrationRepository.retrieveCorporationTaxRegistration(rID) flatMap {
       case Some(doc) =>
+        throwPagerDutyIfTxIDInDBDoesntMatchHandOffTxID(doc.confirmationReferences, handOffRefs.transactionId)
         if (doc.status == DRAFT || doc.status == LOCKED) {
           prepareDocumentForSubmission(rID, authProvId, handOffRefs, doc) flatMap { confRefs =>
             processPartialSubmission(rID, authProvId, confRefs, doc, isAdmin).ifM(
@@ -85,6 +87,16 @@ trait SubmissionService extends DateHelper {
           }
         }
       case None => throw new RuntimeException(s"[handleSubmission] Registration Document not found for regId: $rID")
+    }
+  }
+  private[services] def throwPagerDutyIfTxIDInDBDoesntMatchHandOffTxID(crConfRefs: Option[ConfirmationReferences], hOffTxID: String): Boolean = {
+    crConfRefs.fold(false) {
+      confRef => if(confRef.transactionId != hOffTxID) {
+        Logger.error(s"${PagerDutyKeys.TXID_IN_CR_DOESNT_MATCH_HANDOFF_TXID} - CR txId: ${confRef.transactionId} hand off txId: $hOffTxID ")
+        true
+      } else {
+        false
+      }
     }
   }
 

--- a/app/services/admin/AdminService.scala
+++ b/app/services/admin/AdminService.scala
@@ -217,7 +217,7 @@ trait AdminService extends ScheduledService[Either[Int, LockResponse]] with Date
       case _                                  => Future.successful(false)
     }) recover {
       case e: Throwable =>
-        Logger.warn(s"[processStaleDocument] Failed to delete regId: ${documentInfo.regId} with throwable $e")
+        Logger.warn(s"[processStaleDocument] Failed to delete regId: ${documentInfo.regId} with throwable ${e.getMessage}")
         false
     }
   }
@@ -228,9 +228,9 @@ trait AdminService extends ScheduledService[Either[Int, LockResponse]] with Date
         true
       } { crn =>
         Logger.warn(s"[processStaleDocument] Could not delete document with CRN: $crn " +
-          s"regId: ${documentInfo.regId} transID: ${confRefs.transactionId} lastSignIn: ${documentInfo.lastSignedIn} status: ${documentInfo.status}"
+          s"regId: ${documentInfo.regId} transID: ${confRefs.transactionId} lastSignIn: ${documentInfo.lastSignedIn} status: ${documentInfo.status} paymentRefExists = ${confRefs.paymentReference.isDefined} paymentAmoutExists = ${confRefs.paymentAmount.isDefined} acknowledgmentReference is NOT empty = ${confRefs.acknowledgementReference.nonEmpty}"
         )
-        throw new RuntimeException
+        throw new Exception("No deletion carried out because CRN exists")
       }
     }
   }

--- a/app/utils/AlertLogging.scala
+++ b/app/utils/AlertLogging.scala
@@ -30,6 +30,7 @@ object PagerDutyKeys extends Enumeration {
   val CT_ACCEPTED_MISSING_UTR = Value
   val STALE_DOCUMENTS_DELETE_WARNING_CRN_FOUND = Value
   val CT_ACCEPTED_NO_REG_DOC_II_SUBS_DELETED = Value
+  val TXID_IN_CR_DOESNT_MATCH_HANDOFF_TXID = Value
 }
 
 class AlertLoggingImpl @Inject()(microserviceAppConfig: MicroserviceAppConfig) extends AlertLogging {

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -38,3 +38,5 @@ PUT        /corporation-tax-registration/:registrationID/progress               
 PUT        /corporation-tax-registration/:registrationId/update-email                       @controllers.test.EmailController.updateEmail(registrationId: String)
 GET        /corporation-tax-registration/:registrationId/retrieve-email                     @controllers.test.EmailController.retrieveEmail(registrationId: String)
 
+PUT        /corporation-tax-registration/:registrationId/handOff2Reference-ackRef-save      @controllers.CompanyDetailsController.saveHandOff2ReferenceAndGenerateAckRef(registrationId: String)
+

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -55,6 +55,7 @@
     <logger name="io.netty" level="INFO"/>
     <logger name="org.apache.http" level="INFO"/>
     <logger name="reactivemongo.core" level="INFO"/>
+    <logger name="reactivemongo.core.actors.MongoDBSystem" level="INFO"/>
 
     <logger name="application" level="INFO"/>
 

--- a/test/controllers/SubmissionControllerSpec.scala
+++ b/test/controllers/SubmissionControllerSpec.scala
@@ -39,8 +39,6 @@ import scala.concurrent.Future
 
 class SubmissionControllerSpec extends BaseSpec with AuthorisationMocks with CorporationTaxRegistrationFixture {
 
-  val mockSubmissionService = mock[SubmissionService]
-
   class Setup (nowTime: LocalTime = LocalTime.parse("13:00:00")){
     val controller = new SubmissionController {
       val submissionService = mockSubmissionService

--- a/test/controllers/test/TestEndpointControllerSpec.scala
+++ b/test/controllers/test/TestEndpointControllerSpec.scala
@@ -41,7 +41,6 @@ class TestEndpointControllerSpec extends BaseSpec with LogCapturing {
 
   val mockThrottleRepository = mock[ThrottleMongoRepository]
   val mockCTRepository = mock[CorporationTaxRegistrationMongoRepository]
-  val mockSubmissionService = mock[SubmissionService]
 
   class Setup {
     val controller = new TestEndpointController {

--- a/test/mocks/SCRSMocks.scala
+++ b/test/mocks/SCRSMocks.scala
@@ -16,7 +16,7 @@
 
 package mocks
 
-import auth.{AuthClientConnector, CryptoSCRS}
+import auth.CryptoSCRS
 import connectors.{BusinessRegistrationConnector, IncorporationCheckAPIConnector}
 import models._
 import org.mockito.ArgumentMatchers
@@ -44,6 +44,7 @@ trait SCRSMocks
   lazy val mockIncorporationCheckAPIConnector = mock[IncorporationCheckAPIConnector]
   lazy val mockMetrics = mock[MetricsService]
   lazy val mockProcessIncorporationService = mock[ProcessIncorporationService]
+  lazy val mockSubmissionService = mock[SubmissionService]
   val mockBusRegConnector = mock[BusinessRegistrationConnector]
   val mockLockKeeper = mock[LockKeeper]
   val mockInstanceOfCrypto = new CryptoSCRS {
@@ -108,6 +109,11 @@ trait SCRSMocks
     def retrieveCompanyDetails(registrationID: String, result: Option[CompanyDetails]): OngoingStubbing[Future[Option[CompanyDetails]]] = {
       when(mockCompanyDetailsService.retrieveCompanyDetails(ArgumentMatchers.anyString()))
         .thenReturn(Future.successful(result))
+    }
+
+    def saveTxidAndGenerateAckRef(result: Future[SaveTxIdRes]): OngoingStubbing[Future[SaveTxIdRes]] = {
+      when(mockCompanyDetailsService.saveTxIdAndAckRef(ArgumentMatchers.anyString(),ArgumentMatchers.anyString()))
+        .thenReturn(result)
     }
 
     def updateCompanyDetails(registrationID: String, result: Option[CompanyDetails]): OngoingStubbing[Future[Option[CompanyDetails]]] = {

--- a/test/models/ElementsFromH02ReadsSpec.scala
+++ b/test/models/ElementsFromH02ReadsSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.Json
+import uk.gov.hmrc.play.test.UnitSpec
+
+class ElementsFromH02ReadsSpec extends UnitSpec{
+
+  val jsonParsedTxidInObj = Json.parse(
+    """{
+      | "transaction_id" : "foo"
+      | }
+    """.stripMargin)
+
+  val transactionIdDoesntExist = Json.parse(
+    """{
+      | "transaction_foo" : "bar"
+      |}
+    """.stripMargin
+  )
+  "reads should return a string when jsObject provided containing transaction_id" in {
+    jsonParsedTxidInObj.as[String](ElementsFromH02Reads.reads) shouldBe "foo"
+  }
+  "reads should return jsError if element transaction_id not in obj" in {
+    transactionIdDoesntExist.validate[String](ElementsFromH02Reads.reads).isError shouldBe true
+  }
+
+}

--- a/test/services/CompanyDetailsServiceSpec.scala
+++ b/test/services/CompanyDetailsServiceSpec.scala
@@ -18,14 +18,24 @@ package services
 
 import fixtures.CompanyDetailsFixture
 import mocks.SCRSMocks
+import models.ConfirmationReferences
 import org.scalatest.mockito.MockitoSugar
+import play.api.libs.json.Json
 import uk.gov.hmrc.play.test.UnitSpec
+import org.mockito.Mockito._
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+
+import scala.concurrent.Future
 
 class CompanyDetailsServiceSpec extends UnitSpec with MockitoSugar with SCRSMocks with CompanyDetailsFixture {
 
   trait Setup {
+    reset(mockCTDataRepository)
+    reset(mockSubmissionService)
+
     val service = new CompanyDetailsService {
       override val corporationTaxRegistrationRepository = mockCTDataRepository
+      override val submissionService: SubmissionService = mockSubmissionService
     }
   }
 
@@ -57,6 +67,48 @@ class CompanyDetailsServiceSpec extends UnitSpec with MockitoSugar with SCRSMock
       CTDataRepositoryMocks.updateCompanyDetails(None)
 
       await(service.updateCompanyDetails(registrationID, validCompanyDetails)) shouldBe None
+    }
+  }
+  "convertAckRefToJsObject" should {
+    "return jsObject" in new Setup {
+      service.convertAckRefToJsObject("foo") shouldBe Json.obj("acknowledgement-reference" -> "foo")
+    }
+  }
+
+  "saveTxidAndGenerateAckRef" should {
+    val ackRefJsObject = Json.obj("acknowledgement-reference" -> "fooBar")
+    val conf =  ConfirmationReferences("fooBar","txId",None,None)
+    "return DidNotExistInCRNowSaved containing jsObject with ackref from repo" in new Setup {
+      when(mockCTDataRepository.retrieveConfirmationReferences(any())).thenReturn(Future.successful(None))
+      when(mockSubmissionService.generateAckRef).thenReturn(Future.successful("fooBar"))
+      when(mockCTDataRepository.updateConfirmationReferences(any(),eqTo(conf)))
+        .thenReturn(Future.successful(Some(conf)))
+     val res = await(service.saveTxIdAndAckRef(registrationID, "txId"))
+      verify(mockSubmissionService, times(1)).generateAckRef
+      res shouldBe DidNotExistInCRNowSaved(ackRefJsObject)
+    }
+    "return ExistedInCRAlready with jsObject with ackref when ConfirmationReferences Block already exists" in new Setup {
+      when(mockCTDataRepository.retrieveConfirmationReferences(any())).thenReturn(Future.successful(Some(conf)))
+      val res = await(service.saveTxIdAndAckRef(registrationID, "txId"))
+      verify(mockSubmissionService, times(0)).generateAckRef
+      res shouldBe ExistedInCRAlready(ackRefJsObject)
+    }
+    "return SomethingWentWrongWhenSaving when retrieve fails" in new Setup {
+      val ex = new Exception("foo")
+      when(mockCTDataRepository.retrieveConfirmationReferences(any())).thenReturn(Future.failed(ex))
+      val res = await(service.saveTxIdAndAckRef(registrationID, "txId"))
+      verify(mockSubmissionService, times(0)).generateAckRef
+      res shouldBe SomethingWentWrongWhenSaving(ex,registrationID,"txId")
+    }
+    "return SomethingWentWrongWhenSaving when save fails" in new Setup {
+      val ex = new Exception("bar")
+      when(mockCTDataRepository.retrieveConfirmationReferences(any())).thenReturn(Future.successful(None))
+      when(mockSubmissionService.generateAckRef).thenReturn(Future.successful("foo"))
+      when(mockCTDataRepository.updateConfirmationReferences(any(),any())).thenReturn(Future.failed(ex))
+
+      val res = await(service.saveTxIdAndAckRef(registrationID, "txId"))
+      verify(mockSubmissionService, times(1)).generateAckRef
+      res shouldBe SomethingWentWrongWhenSaving(ex,registrationID,"txId")
     }
   }
 }


### PR DESCRIPTION
* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date 