### PR TITLE
[SAR-10150] Upgrade to Auth Retrievals V2

### DIFF
--- a/app/auth/AuthorisationExceptions.scala
+++ b/app/auth/AuthorisationExceptions.scala
@@ -19,3 +19,4 @@ package auth
 import uk.gov.hmrc.auth.core.AuthorisationException
 
 case class UnauthorisedAccess(msg: String = "Unauthorised Access") extends AuthorisationException(msg)
+case class NoInternalIdRetrieved(msg: String = "No Internal ID retrieved from call to Auth") extends AuthorisationException(msg)

--- a/it/api/SubmissionControllerISpec.scala
+++ b/it/api/SubmissionControllerISpec.scala
@@ -225,7 +225,7 @@ class SubmissionControllerISpec extends IntegrationSpecBase with LoginStub with 
     val authProviderId: String = "testAuthProviderId"
     val authorisedRetrievals: JsObject = Json.obj(
       "internalId" -> internalId,
-      "credentials" -> Json.obj("providerId" -> authProviderId, "providerType" -> "testType"))
+      "optionalCredentials" -> Json.obj("providerId" -> authProviderId, "providerType" -> "testType"))
 
     "return Confirmation References when registration is in Held status" in new Setup {
       stubAuthorise(200, authorisedRetrievals)
@@ -364,8 +364,7 @@ class SubmissionControllerISpec extends IntegrationSpecBase with LoginStub with 
         reg.status shouldBe HELD
       }
 
-      "registration is in Draft sta" +
-        "tus and update Confirmation References with Ack Ref (new HO5-1)" in new Setup {
+      "registration is in Draft status and update Confirmation References with Ack Ref (new HO5-1)" in new Setup {
         stubAuthorise(200, authorisedRetrievals)
 
         val confRefsWithoutPayment: ConfirmationReferences = ConfirmationReferences(

--- a/test/controllers/AccountingDetailsControllerSpec.scala
+++ b/test/controllers/AccountingDetailsControllerSpec.scala
@@ -17,7 +17,6 @@
 package controllers
 
 
-import auth.AuthorisationResource
 import fixtures.AccountingDetailsFixture
 import helpers.BaseSpec
 import mocks.{AuthorisationMocks, MockMetricsService}
@@ -60,7 +59,7 @@ class AccountingDetailsControllerSpec extends BaseSpec with AccountingDetailsFix
   "retrieveAccountingDetails" should {
 
     "return a 200 with accounting details in the js on body when authorised" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       AccountingDetailsServiceMocks.retrieveAccountingDetails(registrationID, Some(validAccountingDetails))
@@ -75,7 +74,7 @@ class AccountingDetailsControllerSpec extends BaseSpec with AccountingDetailsFix
 
 
     "return a 404 when the user is authorised but accounting details cannot be found" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       AccountingDetailsServiceMocks.retrieveAccountingDetails(registrationID, None)
@@ -94,7 +93,7 @@ class AccountingDetailsControllerSpec extends BaseSpec with AccountingDetailsFix
     val request = FakeRequest().withBody(Json.toJson(validAccountingDetails))
 
     "return a 200 with accounting details in the json body when authorised" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       AccountingDetailsServiceMocks.updateAccountingDetails(registrationID, Some(validAccountingDetails))
@@ -105,7 +104,7 @@ class AccountingDetailsControllerSpec extends BaseSpec with AccountingDetailsFix
     }
 
     "return a 404 when the user is authorised but accounting details cannot be found" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       AccountingDetailsServiceMocks.updateAccountingDetails(registrationID, None)

--- a/test/controllers/CompanyDetailsControllerSpec.scala
+++ b/test/controllers/CompanyDetailsControllerSpec.scala
@@ -59,7 +59,7 @@ class CompanyDetailsControllerSpec extends BaseSpec with AuthorisationMocks with
   "retrieveCompanyDetails" should {
 
     "return a 200 and a Company details record when authorised" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       CompanyDetailsServiceMocks.retrieveCompanyDetails(registrationID, Some(validCompanyDetails))
@@ -71,7 +71,7 @@ class CompanyDetailsControllerSpec extends BaseSpec with AuthorisationMocks with
     }
 
     "return a 404 if company details are not found on the CT document" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       CompanyDetailsServiceMocks.retrieveCompanyDetails(registrationID, None)
@@ -82,7 +82,7 @@ class CompanyDetailsControllerSpec extends BaseSpec with AuthorisationMocks with
     }
 
     "return a 404 when the CT document cannot be found" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.failed(new MissingCTDocument("testRegId")))
 
       val result: Future[Result] = controller.retrieveCompanyDetails(registrationID)(FakeRequest())
@@ -90,7 +90,7 @@ class CompanyDetailsControllerSpec extends BaseSpec with AuthorisationMocks with
     }
 
     "return a 403 when the user is unauthorised to access the record" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(otherInternalID))
 
       val result: Future[Result] = controller.retrieveCompanyDetails(registrationID)(FakeRequest())
@@ -110,7 +110,7 @@ class CompanyDetailsControllerSpec extends BaseSpec with AuthorisationMocks with
     val request = FakeRequest().withBody(Json.toJson(validCompanyDetails))
 
     "return a 200 and a company details response if the user is authorised" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       CompanyDetailsServiceMocks.updateCompanyDetails(registrationID, Some(validCompanyDetails))
@@ -121,7 +121,7 @@ class CompanyDetailsControllerSpec extends BaseSpec with AuthorisationMocks with
     }
 
     "return a 404 if the record to update does not exist" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       CompanyDetailsServiceMocks.updateCompanyDetails(registrationID, None)
@@ -132,7 +132,7 @@ class CompanyDetailsControllerSpec extends BaseSpec with AuthorisationMocks with
     }
 
     "return a 404 when the user is authorised but the CT document does not exist" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.failed(new MissingCTDocument("testRegId")))
 
       val result: Future[Result] = controller.updateCompanyDetails(registrationID)(request)
@@ -147,7 +147,7 @@ class CompanyDetailsControllerSpec extends BaseSpec with AuthorisationMocks with
     }
 
     "return a 403 when the user is unauthorised to access the record" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(otherInternalID))
 
       val result: Future[Result] = controller.updateCompanyDetails(registrationID)(request)
@@ -155,7 +155,7 @@ class CompanyDetailsControllerSpec extends BaseSpec with AuthorisationMocks with
     }
 
     "verify that metrics are captured on a successful update" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       CompanyDetailsServiceMocks.updateCompanyDetails(registrationID, Some(validCompanyDetails))
@@ -169,7 +169,7 @@ class CompanyDetailsControllerSpec extends BaseSpec with AuthorisationMocks with
     val ackRefJsObject = Json.obj("acknowledgement-reference" -> "testAckRef")
     val requestContainingTxId = FakeRequest().withBody(Json.obj("transaction_id" -> "testTransactionId"))
     "return 200 as service returned jsObject" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
       CompanyDetailsServiceMocks.saveTxidAndGenerateAckRef(Future.successful(ackRefJsObject))
 
@@ -178,7 +178,7 @@ class CompanyDetailsControllerSpec extends BaseSpec with AuthorisationMocks with
       contentAsJson(result).as[JsObject] shouldBe ackRefJsObject
     }
     "return exception if service returned exception" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
       CompanyDetailsServiceMocks.saveTxidAndGenerateAckRef(Future.failed(new Exception("")))
 
@@ -189,7 +189,7 @@ class CompanyDetailsControllerSpec extends BaseSpec with AuthorisationMocks with
     }
     "return 400 if json incorrect" in new Setup {
       val requestNOTContainingTxId: FakeRequest[JsObject] = FakeRequest().withBody(Json.obj())
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
       val result: Future[Result] = controller.saveHandOff2ReferenceAndGenerateAckRef("testRegId")(requestNOTContainingTxId)
       status(result) shouldBe 400

--- a/test/controllers/ContactDetailsControllerSpec.scala
+++ b/test/controllers/ContactDetailsControllerSpec.scala
@@ -56,7 +56,7 @@ class ContactDetailsControllerSpec extends BaseSpec with AuthorisationMocks with
   "retrieveContactDetails" should {
 
     "return a 200 with contact details in the json body when authorised" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       ContactDetailsServiceMocks.retrieveContactDetails(registrationID, Some(contactDetails))
@@ -67,7 +67,7 @@ class ContactDetailsControllerSpec extends BaseSpec with AuthorisationMocks with
     }
 
     "return a 404 when the user is authorised but contact details cannot be found" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       ContactDetailsServiceMocks.retrieveContactDetails(registrationID, None)
@@ -78,7 +78,7 @@ class ContactDetailsControllerSpec extends BaseSpec with AuthorisationMocks with
     }
 
     "return a 404 when the CT document cannot be found" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.failed(new MissingCTDocument("testRegId")))
 
       val result = controller.retrieveContactDetails(registrationID)(FakeRequest())
@@ -86,7 +86,7 @@ class ContactDetailsControllerSpec extends BaseSpec with AuthorisationMocks with
     }
 
     "return a 403 when the user is unauthorised to access the record" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(otherInternalID))
 
       val result = controller.retrieveContactDetails(registrationID)(FakeRequest())
@@ -106,7 +106,7 @@ class ContactDetailsControllerSpec extends BaseSpec with AuthorisationMocks with
     val request = FakeRequest().withBody(Json.toJson(contactDetails))
 
     "return a 200 with contact details in the json body when authorised" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       ContactDetailsServiceMocks.updateContactDetails(registrationID, Some(contactDetails))
@@ -117,7 +117,7 @@ class ContactDetailsControllerSpec extends BaseSpec with AuthorisationMocks with
     }
 
     "return a 404 when the user is authorised but contact details cannot be found" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       ContactDetailsServiceMocks.updateContactDetails(registrationID, None)
@@ -127,7 +127,7 @@ class ContactDetailsControllerSpec extends BaseSpec with AuthorisationMocks with
     }
 
     "return a 404 when the CT document cannot be found" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.failed(new MissingCTDocument("testRegId")))
 
       val result = controller.updateContactDetails(registrationID)(request)
@@ -135,7 +135,7 @@ class ContactDetailsControllerSpec extends BaseSpec with AuthorisationMocks with
     }
 
     "return a 403 when the user is unauthorised to access the record" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(otherInternalID))
 
       val result = controller.updateContactDetails(registrationID)(request)

--- a/test/controllers/CorporationTaxRegistrationControllerSpec.scala
+++ b/test/controllers/CorporationTaxRegistrationControllerSpec.scala
@@ -68,7 +68,7 @@ class CorporationTaxRegistrationControllerSpec extends BaseSpec with Authorisati
     val request = FakeRequest().withBody(Json.toJson(validCorporationTaxRegistrationRequest))
 
     "return a 201 when a new entry is created from the parsed json" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       when(mockCTDataService.createCorporationTaxRegistrationRecord(eqTo(internalId), eqTo(regId), eqTo("en")))
@@ -78,6 +78,13 @@ class CorporationTaxRegistrationControllerSpec extends BaseSpec with Authorisati
       val result: Future[Result] = controller.createCorporationTaxRegistration(regId)(request)
       status(result) shouldBe CREATED
       contentAsJson(result) shouldBe Json.toJson(response)
+    }
+
+    "return a 403 when no internalId retrieved from Auth" in new Setup {
+      mockAuthorise(Future.successful(None))
+
+      val result: Future[Result] = controller.createCorporationTaxRegistration(regId)(request)
+      status(result) shouldBe FORBIDDEN
     }
 
     "return a 403 when the user is not authorised" in new Setup {
@@ -93,7 +100,7 @@ class CorporationTaxRegistrationControllerSpec extends BaseSpec with Authorisati
     val ctRegistrationResponse = buildCTRegistrationResponse(regId)
 
     "return a 200 and a CorporationTaxRegistration model is one is found" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       when(mockCTDataService.retrieveCorporationTaxRegistrationRecord(eqTo(regId), any()))
@@ -105,7 +112,7 @@ class CorporationTaxRegistrationControllerSpec extends BaseSpec with Authorisati
     }
 
     "return a 404 if a CT registration record cannot be found" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       CTServiceMocks.retrieveCTDataRecord(regId, None)
@@ -125,7 +132,7 @@ class CorporationTaxRegistrationControllerSpec extends BaseSpec with Authorisati
   "retrieveFullCorporationTaxRegistration" should {
 
     "return a 200 and a CorporationTaxRegistration model is found" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       CTServiceMocks.retrieveCTDataRecord(regId, Some(validDraftCorporationTaxRegistration))
@@ -136,7 +143,7 @@ class CorporationTaxRegistrationControllerSpec extends BaseSpec with Authorisati
     }
 
     "return a 404 if a CT registration record cannot be found" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       CTServiceMocks.retrieveCTDataRecord(regId, None)
@@ -156,7 +163,7 @@ class CorporationTaxRegistrationControllerSpec extends BaseSpec with Authorisati
   "retrieveConfirmationReference" should {
 
     "return a 200 and an acknowledgement ref is one exists" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       val expected: ConfirmationReferences = ConfirmationReferences("BRCT00000000123", "tx", Some("py"), Some("12.00"))
@@ -169,7 +176,7 @@ class CorporationTaxRegistrationControllerSpec extends BaseSpec with Authorisati
     }
 
     "return a 404 if a record cannot be found" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       when(mockCTDataService.retrieveConfirmationReferences(ArgumentMatchers.eq(regId)))
@@ -192,7 +199,7 @@ class CorporationTaxRegistrationControllerSpec extends BaseSpec with Authorisati
     def progressRequest(progress: String): JsValue = Json.parse(s"""{"registration-progress":"$progress"}""")
 
     "Extract the progress correctly from the message and request doc is updated" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       val progress: String = "HO5"
@@ -209,7 +216,7 @@ class CorporationTaxRegistrationControllerSpec extends BaseSpec with Authorisati
     }
 
     "Return not found is the doc couldn't be updated" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       val progress = "N/A"

--- a/test/controllers/EmailControllerSpec.scala
+++ b/test/controllers/EmailControllerSpec.scala
@@ -68,7 +68,7 @@ class EmailControllerSpec extends BaseSpec with AuthorisationMocks {
   "retrieveEmail" should {
 
     "return a 200 and an Email json object if the user is authorised" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       when(mockEmailService.retrieveEmail(eqTo(registrationID)))
@@ -87,7 +87,7 @@ class EmailControllerSpec extends BaseSpec with AuthorisationMocks {
     }
 
     "return a 403 when the user is logged in but not authorised to access the resource" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(otherInternalID))
 
       val result: Future[Result] = emailController.retrieveEmail(registrationID)(FakeRequest())
@@ -95,7 +95,7 @@ class EmailControllerSpec extends BaseSpec with AuthorisationMocks {
     }
 
     "return a 404 when the user is logged in but a CT record doesn't exist" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.failed(new MissingCTDocument("hfbhdbf")))
 
       val result: Future[Result] = emailController.retrieveEmail(registrationID)(FakeRequest())
@@ -108,7 +108,7 @@ class EmailControllerSpec extends BaseSpec with AuthorisationMocks {
     val request = FakeRequest().withBody(Json.toJson(email))
 
     "return a 200 and an email json object when the user is authorised" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       when(mockEmailService.updateEmail(eqTo(registrationID), eqTo(email)))
@@ -127,7 +127,7 @@ class EmailControllerSpec extends BaseSpec with AuthorisationMocks {
     }
 
     "return a 403 when the user is logged in but not authorised to access the resource" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(otherInternalID))
 
       val result: Future[Result] = emailController.updateEmail(registrationID)(request)
@@ -135,7 +135,7 @@ class EmailControllerSpec extends BaseSpec with AuthorisationMocks {
     }
 
     "return a 404 when the user is authorised but the CT document doesn't exist" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.failed(new MissingCTDocument("hfbhdbf")))
 
       val result: Future[Result] = emailController.updateEmail(registrationID)(request)

--- a/test/controllers/GroupsControllerSpec.scala
+++ b/test/controllers/GroupsControllerSpec.scala
@@ -97,21 +97,21 @@ class GroupsControllerSpec extends BaseSpec with AuthorisationMocks {
 
   "deleteBlock" should {
     "return 204 if groups deleted successfully" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
       when(mockGroupsService.deleteGroups(eqTo(regId))).thenReturn(Future.successful(true))
       val res: Future[Result] = controller.deleteBlock(regId)(FakeRequest())
       status(res) shouldBe NO_CONTENT
     }
     "return 500 if false is returned from deleteGroups" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
       when(mockGroupsService.deleteGroups(eqTo(regId))).thenReturn(Future.successful(false))
       val res: Future[Result] = controller.deleteBlock(regId)(FakeRequest())
       status(res) shouldBe INTERNAL_SERVER_ERROR
     }
     "return exception if groups returns future failed" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
       when(mockGroupsService.deleteGroups(eqTo(regId))).thenReturn(Future.failed(new Exception("Failure Reason")))
       intercept[Exception](await(controller.deleteBlock(regId)(FakeRequest())))
@@ -120,7 +120,7 @@ class GroupsControllerSpec extends BaseSpec with AuthorisationMocks {
   "getBlock" should {
 
     "return 200 with json body of group if group complete" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
       when(mockGroupsService.returnGroups(eqTo(regId))).thenReturn(Future.successful(Some(validGroupsModel)))
       val res: Future[Result] = controller.getBlock(regId)(FakeRequest())
@@ -151,7 +151,7 @@ class GroupsControllerSpec extends BaseSpec with AuthorisationMocks {
         """.stripMargin)
     }
     "return 200 if the user has selected No previously to the page group relief" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
       when(mockGroupsService.returnGroups(eqTo(regId))).thenReturn(Future.successful(Some(Groups(groupRelief = false, None, None, None))))
       val res: Future[Result] = controller.getBlock(regId)(FakeRequest())
@@ -164,14 +164,14 @@ class GroupsControllerSpec extends BaseSpec with AuthorisationMocks {
         """.stripMargin)
     }
     "return 204 if block does not exist" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
       when(mockGroupsService.returnGroups(eqTo(regId))).thenReturn(Future.successful(None))
       val res: Future[Result] = controller.getBlock(regId)(FakeRequest())
       status(res) shouldBe NO_CONTENT
     }
     "return exception if returnGroups returns an exception" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
       when(mockGroupsService.returnGroups(eqTo(regId))).thenReturn(Future.failed(new Exception("Failure Reason")))
       intercept[Exception](await(controller.getBlock(regId)(FakeRequest())))
@@ -228,7 +228,7 @@ class GroupsControllerSpec extends BaseSpec with AuthorisationMocks {
           |   }
           |}
         """.stripMargin)
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
       when(mockGroupsService.updateGroups(eqTo(regId), any())).thenReturn(Future.successful(validGroupsModel.copy(groupRelief = false)))
       val res: Future[Result] = controller.saveBlock(regId)(request)
@@ -257,7 +257,7 @@ class GroupsControllerSpec extends BaseSpec with AuthorisationMocks {
           |   }
           |}
         """.stripMargin))
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       intercept[Exception](await(controller.saveBlock(regId)(request)))
@@ -287,7 +287,7 @@ class GroupsControllerSpec extends BaseSpec with AuthorisationMocks {
           |}
         """.stripMargin))
 
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       val res: Future[Result] = controller.saveBlock(regId)(request)

--- a/test/controllers/HeldControllerSpec.scala
+++ b/test/controllers/HeldControllerSpec.scala
@@ -112,7 +112,7 @@ class HeldControllerSpec extends BaseSpec with AuthorisationMocks {
   "deleteSubmissionData" should {
 
     "return a 200 response when a user is logged in and their rejected submission data is deleted" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       when(controller.service.deleteRejectedSubmissionData(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(true))
@@ -122,7 +122,7 @@ class HeldControllerSpec extends BaseSpec with AuthorisationMocks {
     }
 
     "return a 404 (Not found) response when a user's rejected submission data is not found" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       when(controller.service.deleteRejectedSubmissionData(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(false))

--- a/test/controllers/TakeoverDetailsControllerSpec.scala
+++ b/test/controllers/TakeoverDetailsControllerSpec.scala
@@ -67,7 +67,7 @@ class TakeoverDetailsControllerSpec extends BaseSpec with AuthorisationMocks {
 
   "getBlock" should {
     "successfully retrieve a json with a valid TakeoverDetails and a 200 status if the data exists" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       when(mockTakeoverDetailsService.retrieveTakeoverDetailsBlock(registrationId)).thenReturn(Future.successful(Some(validTakeoverDetailsModel)))
@@ -97,7 +97,7 @@ class TakeoverDetailsControllerSpec extends BaseSpec with AuthorisationMocks {
       )
     }
     "retrieve an empty json and a 204 response if the data is not found" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       when(mockTakeoverDetailsService.retrieveTakeoverDetailsBlock(registrationId)).thenReturn(Future.successful(None))
@@ -109,7 +109,7 @@ class TakeoverDetailsControllerSpec extends BaseSpec with AuthorisationMocks {
 
   "putSubmission" should {
     "return a 200 response if the TakeoverDetails json is valid" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
       val request: FakeRequest[JsObject] = FakeRequest().withBody(Json.obj(
         "replacingAnotherBusiness" -> true,
@@ -140,7 +140,7 @@ class TakeoverDetailsControllerSpec extends BaseSpec with AuthorisationMocks {
     }
 
     "return a 400 response if the TakeoverDetails json is invalid" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
       val request: FakeRequest[JsObject] = FakeRequest().withBody(Json.obj(
         "replacingAnotherBusiness" -> true,
@@ -168,7 +168,7 @@ class TakeoverDetailsControllerSpec extends BaseSpec with AuthorisationMocks {
       status(result) shouldBe BAD_REQUEST
     }
     "return an exception if the request is missing fields" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
       val request: FakeRequest[JsObject] = FakeRequest().withBody(Json.obj(
         "replacingAnotherBusiness" -> true,

--- a/test/controllers/TradingDetailsControllerSpec.scala
+++ b/test/controllers/TradingDetailsControllerSpec.scala
@@ -77,7 +77,7 @@ class TradingDetailsControllerSpec extends BaseSpec with MockitoSugar with SCRSM
   "retrieveTradingDetails" should {
     "retrieve a 200 - Ok and a Json package of TradingDetails" in new Setup {
 
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       when(mockTradingDetailsService.retrieveTradingDetails(ArgumentMatchers.eq(regID)))
@@ -92,7 +92,7 @@ class TradingDetailsControllerSpec extends BaseSpec with MockitoSugar with SCRSM
 
     "return a 404 - Not Found if the record does not exist" in new Setup {
 
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       when(mockTradingDetailsService.retrieveTradingDetails(ArgumentMatchers.eq(regID)))
@@ -111,7 +111,7 @@ class TradingDetailsControllerSpec extends BaseSpec with MockitoSugar with SCRSM
     }
 
     "return a 403 - Forbidden if the user is not authorised to view this record" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(otherInternalID))
 
       val result: Future[Result] = controller.retrieveTradingDetails(regID)(FakeRequest())
@@ -119,7 +119,7 @@ class TradingDetailsControllerSpec extends BaseSpec with MockitoSugar with SCRSM
     }
 
     "return a 404 - Not found when an authority is found but nothing is returned from" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       val result: Future[Result] = controller.retrieveTradingDetails(regID)(FakeRequest())
@@ -129,7 +129,7 @@ class TradingDetailsControllerSpec extends BaseSpec with MockitoSugar with SCRSM
 
   "updateTradingDetails" should {
     "return a 200 - Ok and a company details response if a record is updated" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       when(mockTradingDetailsService.updateTradingDetails(ArgumentMatchers.eq("testRegID"), ArgumentMatchers.eq(TradingDetails("true"))))
@@ -143,7 +143,7 @@ class TradingDetailsControllerSpec extends BaseSpec with MockitoSugar with SCRSM
     }
 
     "return a 404 - Not Found if the record to update does not exist" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       when(mockTradingDetailsService.updateTradingDetails(ArgumentMatchers.eq("testRegID"), ArgumentMatchers.eq(TradingDetails("true"))))
@@ -165,7 +165,7 @@ class TradingDetailsControllerSpec extends BaseSpec with MockitoSugar with SCRSM
     }
 
     "return a 403 - Forbidden if the user is not authorised to view the record" in new Setup {
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(otherInternalID))
 
       val request: FakeRequest[JsValue] = FakeRequest().withBody(Json.toJson(TradingDetails("true")))
@@ -176,7 +176,7 @@ class TradingDetailsControllerSpec extends BaseSpec with MockitoSugar with SCRSM
 
     "return a 404 - Not found when an authority is found but nothing is updated" in new Setup {
 
-      mockAuthorise(Future.successful(internalId))
+      mockAuthorise(Future.successful(Some(internalId)))
       mockGetInternalId(Future.successful(internalId))
 
       when(mockTradingDetailsService.updateTradingDetails(ArgumentMatchers.eq(regID), ArgumentMatchers.eq(TradingDetails("true"))))


### PR DESCRIPTION
Introduces optionality for the `internalId` and the `credentials` retrievals. Assumption here is that as these are required by the Application the only option would be to throw a `Forbidden` result.