### PR TITLE
[DL-17646] Remove UpdateTransactionId from start-up job now that fix has been applied

### DIFF
--- a/app/config/AppStartupJobs.scala
+++ b/app/config/AppStartupJobs.scala
@@ -20,7 +20,6 @@ import models.TakeoverDetails
 import org.apache.pekko.actor.ActorSystem
 import play.api.Configuration
 import repositories.CorporationTaxRegistrationMongoRepository
-import services.admin.AdminService
 import services.{MetricsService, TakeoverDetailsService}
 import utils.Logging
 
@@ -38,8 +37,7 @@ class Startup @Inject() (appStartupJobs: AppStartupJobs, actorSystem: ActorSyste
 class AppStartupJobsImpl @Inject() (val config: Configuration,
                                     val ctRepo: CorporationTaxRegistrationMongoRepository,
                                     val takeoverDetailsService: TakeoverDetailsService,
-                                    val metricsService: MetricsService,
-                                    val adminService: AdminService)(implicit val ec: ExecutionContext)
+                                    val metricsService: MetricsService)(implicit val ec: ExecutionContext)
     extends AppStartupJobs
 
 trait AppStartupJobs extends Logging {
@@ -49,7 +47,6 @@ trait AppStartupJobs extends Logging {
   val ctRepo: CorporationTaxRegistrationMongoRepository
   val takeoverDetailsService: TakeoverDetailsService
   val metricsService: MetricsService
-  val adminService: AdminService
 
   private def startupStats: Future[Unit] =
     ctRepo.getRegistrationStats map { stats =>
@@ -116,12 +113,6 @@ trait AppStartupJobs extends Logging {
   def runEverythingOnStartUp(): Future[Unit] = {
     logger.info("[runEverythingOnStartUp] Running Startup Jobs")
     lazy val regId = config.get[String]("companyNameRegID")
-    logger.info("[runEverythingOnStartUp] Get details PRE-update:")
-    getCTCompanyName(regId)
-    adminService
-      .updateTransactionId("089-838162", "099-584905")
-      .map(result => logger.info(s"[runEverythingOnStartUp] Was update TxnID successful? - $result"))
-    logger.info("[runEverythingOnStartUp] Get details POST-update:")
     getCTCompanyName(regId)
 
     lazy val base64TakeoverRegIds = config.get[String]("list-of-takeover-regids")

--- a/test/config/AppStartupJobsSpec.scala
+++ b/test/config/AppStartupJobsSpec.scala
@@ -28,7 +28,6 @@ import org.scalatestplus.play.PlaySpec
 import play.api.Configuration
 import play.api.test.Helpers._
 import repositories._
-import services.admin.AdminService
 import services.{MetricsService, TakeoverDetailsService}
 import utils.LogCapturingHelper
 
@@ -42,7 +41,6 @@ class AppStartupJobsSpec extends PlaySpec with MockitoSugar with LogCapturingHel
   val mockCTRepository: CorporationTaxRegistrationMongoRepository = mock[CorporationTaxRegistrationMongoRepository]
   val mockTakeoverDetailsService: TakeoverDetailsService          = mock[TakeoverDetailsService]
   val mockMetricsService: MetricsService                          = mock[MetricsService]
-  val mockAdminService: AdminService                              = mock[AdminService]
 
   val expectedLockedReg: Seq[Nothing] = List()
   val expectedRegStats                = Map.empty[String, Int]
@@ -52,9 +50,8 @@ class AppStartupJobsSpec extends PlaySpec with MockitoSugar with LogCapturingHel
     implicit val ec: ExecutionContext                              = global
     override val takeoverDetailsService: TakeoverDetailsService    = mockTakeoverDetailsService
     override val metricsService: MetricsService                    = mockMetricsService
-    override val adminService: AdminService                        = mockAdminService
     override val ctRepo: CorporationTaxRegistrationMongoRepository = mockCTRepository
-    override def runEverythingOnStartUp: Future[Unit]              = Future.successful(())
+    override def runEverythingOnStartUp(): Future[Unit]            = Future.successful(())
   }
 
   "get Company Name" must {

--- a/test/jobs/TakeoverJobSpec.scala
+++ b/test/jobs/TakeoverJobSpec.scala
@@ -26,7 +26,7 @@ import org.scalatestplus.play.PlaySpec
 import play.api.Configuration
 import play.api.test.Helpers._
 import repositories._
-import services.admin.{AdminService, AdminServiceImpl}
+import services.admin.AdminServiceImpl
 import services.{MetricsService, TakeoverDetailsService}
 import utils.Logging
 
@@ -100,7 +100,6 @@ class TakeoverJobSpec extends PlaySpec with MockitoSugar with Logging with Event
         implicit val ec: ExecutionContext                              = global
         override val takeoverDetailsService: TakeoverDetailsService    = mockTakeoverDetailsService
         override val metricsService: MetricsService                    = mockMetricsService
-        override val adminService: AdminService                        = mockAdminService
         override val ctRepo: CorporationTaxRegistrationMongoRepository = mockCTRepository
 
         override def runEverythingOnStartUp(): Future[Unit] = Future.successful(())


### PR DESCRIPTION
This reverts the changes by this [PR](https://github.com/hmrc/company-registration/pull/336) now that the fix has been applied.